### PR TITLE
Gsliders display correct mimetype image

### DIFF
--- a/erpnext/projects/doctype/project/project.js
+++ b/erpnext/projects/doctype/project/project.js
@@ -262,7 +262,7 @@ async function insertCarousel(frm) {
 					['attached_to_name', 'in', frm.doc.name],
 					['attached_to_doctype', '=', "Project"]
 				],
-				fields: ["file_url"],
+				fields: ["file_url", "file_type"],
 				limit: 10
 			}).then((attachments) => {
 				const tracker = document.querySelector('.glider-track')
@@ -325,6 +325,8 @@ async function insertCarousel(frm) {
 
 function setListeners(el, attachment) {
 	let element = el
+
+	if(attachment.file_type === "MOV" || attachment.file_type === "MP4") return null
 	if (attachment.file_type === 'PDF' || attachment.file_url === 'TXT') {
 		element = el.querySelector('#touch-overlay')
 	}
@@ -335,14 +337,26 @@ function setListeners(el, attachment) {
 
 function createAttachmentElement(attachment) {
 	let el;
-	if (attachment.file_type === "PDF" || attachment.file_type === "TXT") {
-		el = document.createElement('div')
-		el.style = `width: 100%;overflow: hidden; position: relative;`
-		el.innerHTML = `<iframe src="${attachment.file_url}" frameborder="0" class="glider-iframe"></iframe> <div id="touch-overlay"></div>`
-	} else {
-		el = document.createElement('img')
-		el.setAttribute('src', attachment.file_url)
+
+	switch(attachment.file_type){
+		case "PDF":
+		case "TXT":
+			el = document.createElement('div')
+			el.style = `width: 100%;overflow: hidden; position: relative;`
+			el.innerHTML = `<iframe src="${attachment.file_url}" frameborder="0" class="glider-iframe"></iframe> <div id="touch-overlay"></div>`
+			break;
+		case "MOV":
+			case "MP4":
+			el = document.createElement('video')
+			el.className = 'video-container'
+			el.setAttribute('controls', 'true')
+			el.setAttribute('src',attachment.file_url)
+			break;
+		default:
+			el = document.createElement('img')
+			el.setAttribute('src', attachment.file_url)
 	}
+
 	return el
 }
 

--- a/erpnext/projects/doctype/project/project.js
+++ b/erpnext/projects/doctype/project/project.js
@@ -304,40 +304,65 @@ async function insertCarousel(frm) {
 				}
 
 				if (attachments && attachments.length > 0 && glider) {
-					container.style = 'height: auto;'
+					container.style = 'height: auto;overflow:hidden;'
 
 					for (const attachment of attachments) {
-						const img = document.createElement('img')
-						img.setAttribute('src', attachment.file_url)
-						img.addEventListener('touchstart', (e) => handleTouchStart(e, attachment.file_url))
-						img.addEventListener('touchend', handleTouchEnd)
-						glider.addItem(img)
+						const el = createAttachmentElement(attachment)
+						if (el) {
+							setListeners(el, attachment)
+							glider.addItem(el)
+						}
 					}
 
 				} else {
-					container.style = 'height: 0;'
+					container.style = 'height: 0;overflow:hidden;'
 					console.log('No attachments found for this project.');
 				}
 			})
-		}, 2000)// if this time is less than 2 sec it'll be render a wrong carousel
+		}, 3000)// if this time is less than 3 sec it'll be render a wrong carousel
 	})
 }
 
-function handleTouchStart(e, url) {
+function setListeners(el, attachment) {
+	let element = el
+	if (attachment.file_type === 'PDF' || attachment.file_url === 'TXT') {
+		element = el.querySelector('#touch-overlay')
+	}
+	element.addEventListener('touchstart', (e) => handleTouchStart(e, attachment))
+	element.addEventListener('touchend', handleTouchEnd)
+
+}
+
+function createAttachmentElement(attachment) {
+	let el;
+	if (attachment.file_type === "PDF" || attachment.file_type === "TXT") {
+		el = document.createElement('div')
+		el.style = `width: 100%;overflow: hidden; position: relative;`
+		el.innerHTML = `<iframe src="${attachment.file_url}" frameborder="0" class="glider-iframe"></iframe> <div id="touch-overlay"></div>`
+	} else {
+		el = document.createElement('img')
+		el.setAttribute('src', attachment.file_url)
+	}
+	return el
+}
+
+
+function handleTouchStart(e, attachment) {
 	touchTimeout = setTimeout(() => {
-		const imageContainer = document.querySelector('#selected-attachment')
-		const img = imageContainer.querySelector('img')
-		img.setAttribute('src', url)
-		img.addEventListener('touchend', handleTouchEnd)
-		imageContainer.removeAttribute('hidden')
+		const attachmentContainer = document.querySelector('#selected-attachment')
+		const el = createAttachmentElement(attachment)
+		attachmentContainer.addEventListener('touchend', handleTouchEnd)
+		attachmentContainer.appendChild(el)
+		attachmentContainer.removeAttribute('hidden')
 	}, 1000)
 }
 
 function handleTouchEnd(e) {
 	clearTimeout(touchTimeout)
-	const imageContainer = document.querySelector('#selected-attachment')
-	if (imageContainer) {
-		imageContainer.setAttribute('hidden', "true")
+	const attachmentContainer = document.querySelector('#selected-attachment')
+	if (attachmentContainer) {
+		attachmentContainer.innerHTML = ``
+		attachmentContainer.setAttribute('hidden', "true")
 	}
 }
 

--- a/erpnext/public/js/glider.bundle.js
+++ b/erpnext/public/js/glider.bundle.js
@@ -6,7 +6,7 @@ import 'glider-js';
   const imageContainer = document.createElement('div')
 
   el.className = 'glider-contain'
-  el.style = 'width: 90% !important;'
+  el.style = 'width: 90% !important;height: 0;overflow:hidden;'
   el.innerHTML = `
 			<div class="glider"></div>
 			<button aria-label="Previous" class="glider-prev">«</button>
@@ -16,7 +16,6 @@ import 'glider-js';
   imageContainer.className = 'selected-attachment'
   imageContainer.setAttribute('id', 'selected-attachment')
   imageContainer.setAttribute('hidden', 'true')
-  imageContainer.innerHTML = `<img src="" />`
 
   container.append(el, imageContainer)
 })()

--- a/erpnext/public/scss/erpnext.scss
+++ b/erpnext/public/scss/erpnext.scss
@@ -505,8 +505,27 @@ body[data-route="pos"] {
 	transform: translate(-50%, -50%) scale(1);
 }
 
+.glider-slide {
+	margin: 0 8px;
+}
+
 #touch-overlay{
 	position: absolute; top: 0; left: 0; width: 100%; height: 100%;
+}
+
+.video-container {
+	width: 100%;
+	overflow: hidden;
+	position: relative;
+}
+.video-container video {
+	position: absolute;
+	top: 50%;
+	left: 50%;
+	width: 100%;
+	height: 100%;
+	object-fit: contain;
+	transform: translate(-50%, -50%);
 }
 
 .selected-attachment {

--- a/erpnext/public/scss/erpnext.scss
+++ b/erpnext/public/scss/erpnext.scss
@@ -493,6 +493,22 @@ body[data-route="pos"] {
 
 //Attachments carousel
 
+.glider-iframe{
+	width: 100%;
+	height: 100%;
+	border: none;
+	transform: scale(1);
+	transform-origin: top left;
+	position: absolute;
+	top: 50%;
+	left: 50%;
+	transform: translate(-50%, -50%) scale(1);
+}
+
+#touch-overlay{
+	position: absolute; top: 0; left: 0; width: 100%; height: 100%;
+}
+
 .selected-attachment {
 	position: fixed;
 	top: 0;left:0;


### PR DESCRIPTION
This PR updates the carousel to properly display files other than images, so you can now see pdf and txt alongside images.