### PR TITLE
feat(quotation): send quote by email to project customer

### DIFF
--- a/erpnext/selling/doctype/quotation/quotation.js
+++ b/erpnext/selling/doctype/quotation/quotation.js
@@ -1426,6 +1426,82 @@ function show_builder_dialog(frm, bundle) {
 	dialog.show();
 }
 
+// ---------------------------------------------------------------------------
+// Send a submitted Quotation by email.
+// Shows a "Send by Email" button once the Quotation is submitted (docstatus 1).
+// The recipient is resolved from the linked Project's customer; on confirm we
+// POST to {aws_url}quotation/send-email (aws_url from the Rest Config doctype),
+// which sends the SendGrid dynamic template on the backend.
+// ---------------------------------------------------------------------------
+frappe.ui.form.on("Quotation", {
+	refresh(frm) {
+		if (frm.doc.docstatus !== 1) {
+			return;
+		}
+		frm.add_custom_button(__("Send by Email"), () => send_quotation_by_email(frm));
+	},
+});
+
+function send_quotation_by_email(frm) {
+	if (!frm.doc.project_name) {
+		frappe.msgprint(__("Link this Quotation to a Project first."));
+		return;
+	}
+	// Resolve the recipient (Project's customer email) so the user can confirm it.
+	frappe
+		.call({
+			method: "erpnext.selling.doctype.quotation.quotation.get_quotation_recipient",
+			args: { name: frm.doc.name },
+		})
+		.then((r) => {
+			const recipient = r && r.message;
+			if (!recipient) {
+				frappe.msgprint(__("No email found on the Project's customer."));
+				return;
+			}
+			frappe.confirm(__("Send quotation {0} to {1}?", [frm.doc.name, recipient]), () =>
+				post_quotation_send_email(frm, recipient)
+			);
+		});
+}
+
+async function post_quotation_send_email(frm, recipient) {
+	const { aws_url } = await frappe.db.get_doc("Rest Config");
+	if (!aws_url) {
+		frappe.msgprint(__("Set the AWS URL in Rest Config first."));
+		return;
+	}
+	const url = `${aws_url}quotation/send-email`;
+	const payload = {
+		doctype: "Quotation",
+		name: frm.doc.name,
+		email: recipient,
+		party_name: frm.doc.party_name,
+		customer_name: frm.doc.customer_name,
+		project: frm.doc.project_name,
+		grand_total: frm.doc.grand_total,
+	};
+
+	frappe.dom.freeze(__("Sending..."));
+	fetch(url, {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify(payload),
+	})
+		.then((response) => {
+			frappe.dom.unfreeze();
+			if (!response.ok) {
+				throw new Error(`HTTP ${response.status}`);
+			}
+			frappe.show_alert({ message: __("Quotation sent to {0}", [recipient]), indicator: "green" }, 7);
+		})
+		.catch((error) => {
+			frappe.dom.unfreeze();
+			frappe.show_alert({ message: __("An error occurred while sending the email"), indicator: "red" }, 10);
+			console.error("Error:", error);
+		});
+}
+
 async function insertResendQuotationApprovalButton(frm) {
 	if (!["Approved", "Ordered"].includes(frm.doc.status)) {
 		frm.add_custom_button(__('Resend Approve Message'), () => {

--- a/erpnext/selling/doctype/quotation/quotation.py
+++ b/erpnext/selling/doctype/quotation/quotation.py
@@ -607,3 +607,32 @@ def handle_mandatory_error(e, customer, lead_name):
 	message += _("Please create Customer from Lead {0}.").format(get_link_to_form("Lead", lead_name))
 
 	frappe.throw(message, title=_("Mandatory Missing"))
+
+
+def _get_project_customer_email(doc):
+	"""Resolve the recipient email from the Quotation's Project -> Customer.
+
+	Returns the customer's email (from Customer.email_id, fetched from the
+	primary contact) or None when it cannot be determined.
+	"""
+	if not doc.project_name:
+		return None
+
+	customer = frappe.db.get_value("Project", doc.project_name, "customer")
+	if not customer:
+		return None
+
+	return frappe.db.get_value("Customer", customer, "email_id")
+
+
+@frappe.whitelist()
+def get_quotation_recipient(name: str):
+	"""Return the email the Quotation would be sent to (Project's customer).
+
+	Used by the "Send by Email" button to show the recipient for confirmation.
+	The actual send is performed by the backend endpoint POST /quotation/send-email
+	(see quotation.js), which handles the SendGrid dynamic template.
+	"""
+	doc = frappe.get_doc("Quotation", name)
+	doc.check_permission("read")
+	return _get_project_customer_email(doc)


### PR DESCRIPTION
Add a 'Send by Email' button on submitted Quotations. The recipient is resolved from the linked Project's customer (Project -> Customer.email_id) and shown for confirmation; on confirm the client POSTs to {aws_url}quotation/send-email (aws_url from Rest Config), which sends the SendGrid dynamic template on the backend.

- quotation.py: _get_project_customer_email + get_quotation_recipient
- quotation.js: button, recipient confirmation, POST to backend endpoint

<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/erpnext/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
